### PR TITLE
Add new ServiceAccountCredentialsTemplate, mark ServiceAccountTemplate as deprecated

### DIFF
--- a/gcputil/iam_admin.go
+++ b/gcputil/iam_admin.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	// ServiceAccountTemplate is used with Google IAM v1 and is deprecated. Use
-	// ServiceAccountCredentialsTemplate with  Service Account Credentials API v1
+	// ServiceAccountTemplate is used with Google IAM v1. 
+	//
+	// Deprecated: Use ServiceAccountCredentialsTemplate with Service Account Credentials API v1
 	// instead. See https://cloud.google.com/iam/docs/migrating-to-credentials-api
 	// ServiceAccountTemplate is used with
 	// https://pkg.go.dev/google.golang.org/api@v0.3.0/iam/v1

--- a/gcputil/iam_admin.go
+++ b/gcputil/iam_admin.go
@@ -2,13 +2,23 @@ package gcputil
 
 import (
 	"fmt"
+
 	"google.golang.org/api/iam/v1"
 )
 
 const (
-	ServiceAccountTemplate    = "projects/%s/serviceAccounts/%s"
-	ServiceAccountKeyTemplate = "projects/%s/serviceAccounts/%s/keys/%s"
-	ServiceAccountKeyFileType = "TYPE_X509_PEM_FILE"
+	// ServiceAccountTemplate is used with Google IAM v1 and is deprecated. Use
+	// ServiceAccountCredentialsTemplate with  Service Account Credentials API v1
+	// instead. See https://cloud.google.com/iam/docs/migrating-to-credentials-api
+	// ServiceAccountTemplate is used with
+	// https://pkg.go.dev/google.golang.org/api@v0.3.0/iam/v1
+	ServiceAccountTemplate = "projects/%s/serviceAccounts/%s"
+
+	// ServiceAccountTemplate is used with
+	// https://pkg.go.dev/google.golang.org/api@v0.3.0/iamcredentials/v1
+	ServiceAccountCredentialsTemplate = "projects/-/serviceAccounts/%s"
+	ServiceAccountKeyTemplate         = "projects/%s/serviceAccounts/%s/keys/%s"
+	ServiceAccountKeyFileType         = "TYPE_X509_PEM_FILE"
 )
 
 type ServiceAccountId struct {

--- a/gcputil/iam_admin.go
+++ b/gcputil/iam_admin.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	// ServiceAccountTemplate is used with Google IAM v1. 
+	// ServiceAccountTemplate is used with Google IAM v1.
 	//
 	// Deprecated: Use ServiceAccountCredentialsTemplate with Service Account Credentials API v1
 	// instead. See https://cloud.google.com/iam/docs/migrating-to-credentials-api
@@ -15,7 +15,7 @@ const (
 	// https://pkg.go.dev/google.golang.org/api@v0.3.0/iam/v1
 	ServiceAccountTemplate = "projects/%s/serviceAccounts/%s"
 
-	// ServiceAccountTemplate is used with
+	// ServiceAccountCredentialsTemplate is used with
 	// https://pkg.go.dev/google.golang.org/api@v0.3.0/iamcredentials/v1
 	ServiceAccountCredentialsTemplate = "projects/-/serviceAccounts/%s"
 	ServiceAccountKeyTemplate         = "projects/%s/serviceAccounts/%s/keys/%s"

--- a/go.sum
+++ b/go.sum
@@ -70,7 +70,6 @@ go.opencensus.io v0.19.1/go.mod h1:gug0GbSHa8Pafr0d2urOSgoXHZ6x/RUlaiT0d9pqb4A=
 go.opencensus.io v0.19.2 h1:ZZpq6xI6kv/LuE/5s5UQvBU5vMjvRnPb8PvJrIntAnc=
 go.opencensus.io v0.19.2/go.mod h1:NO/8qkisMZLZ1FCsKNqtJPwc8/TaclWyY0B6wcYNg9M=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -90,7 +89,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJV
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
-golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 h1:Wo7BWFiOk0QRFMLYMqJGFMd9CgUAcGx7V+qEg/h5IBI=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914 h1:jIOcLT9BZzyJ9ce+IwwZ+aF9yeCqzrR+NrD68a/SHKw=
 golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
The IAM API is deprecating its [`SignJwt` and `SignBlob` endpoints](https://cloud.google.com/iam/docs/migrating-to-credentials-api). 

This PR updates the `ServiceAccountTemplate` template to make note of that, and adds a new template string to use, `ServiceAccountCredentialsTemplate`. 

Alternatively we could just update the `ServiceAccountTemplate` instead of adding `ServiceAccountCredentialsTemplate`, however, I felt this was a cleaner and more explicit path forward. 

See also: https://github.com/hashicorp/vault-plugin-auth-gcp/pull/108

**Note:** The changes to `go.sum` reflect a `go mod tidy` operation; I get the same changes if I run that on the `master` branch