### PR TITLE
Escape `.` in regex to solve security vulnerability

### DIFF
--- a/gcputil/resource_name.go
+++ b/gcputil/resource_name.go
@@ -11,7 +11,7 @@ const (
 	resourceIdRegex   = "^[^\t\n\f\r]+$"
 	collectionIdRegex = "^[a-z][a-zA-Z]*$"
 
-	fullResourceNameRegex = "^//([a-z]+).googleapis.com/(.+)$"
+	fullResourceNameRegex = "^//([a-z]+)\\.googleapis\\.com/(.+)$"
 	selfLinkMarker        = "projects/"
 )
 

--- a/gcputil/resource_name.go
+++ b/gcputil/resource_name.go
@@ -11,7 +11,7 @@ const (
 	resourceIdRegex   = "^[^\t\n\f\r]+$"
 	collectionIdRegex = "^[a-z][a-zA-Z]*$"
 
-	fullResourceNameRegex = "^//([a-z]+)\\.googleapis\\.com/(.+)$"
+	fullResourceNameRegex = `^//([a-z]+)\.googleapis\.com/(.+)$`
 	selfLinkMarker        = "projects/"
 )
 

--- a/gcputil/resource_name_test.go
+++ b/gcputil/resource_name_test.go
@@ -58,6 +58,8 @@ func TestParseFullResourceName(t *testing.T) {
 		"not/a/real/link":                      {ShouldError: true},
 		"https://aselflink.com/v1/foo/A/bar/B": {ShouldError: true},
 		"https://a.fake.service.com/v1/foo/A/bar/B": {ShouldError: true},
+		"//aserviceXgoogleapis.com/foos/A/bars/B":   {ShouldError: true},
+		"//aservice.googleapisXcom/foos/A/bars/B":   {ShouldError: true},
 		"//aservice.googleapis.com/foos/A/bars/B": {
 			ShouldError: false,
 			Expected: &FullResourceName{


### PR DESCRIPTION
A regex in one of the methods did not escape `.` characters when being directed to `.googleapis.com`. This was vulnerable to attack, described in code-scanning issue linked below.

Solves: https://github.com/hashicorp/go-gcp-common/security/code-scanning/1

Testing:
- Unit tests on GCP Secrets ✅ 
- Unit tests on GCP Auth ✅ 
- Acceptance tests with GCP Secrets ✅ 
- Acceptance tests with GCP Auth ✅ 